### PR TITLE
fixed default border width keybinding

### DIFF
--- a/archcraft-dwm/source/config.def.h
+++ b/archcraft-dwm/source/config.def.h
@@ -8,7 +8,7 @@
 
 /* ******************** Configurations ******************** */
 static const unsigned int borderpx  		= 1;	/* border pixel of windows */
-static const unsigned int default_border 	= 1;	// to switch back to default border after dynamic border resizing via keybinds
+static const unsigned int default_border 	= 0;	// to switch back to default border after dynamic border resizing via keybinds
 static const unsigned int snap      		= 32;	/* snap pixel */
 static const unsigned int gappih    		= 5;	/* horiz inner gap between windows */
 static const unsigned int gappiv    		= 5;	/* vert inner gap between windows */


### PR DESCRIPTION
Earlier the keybinding `mod + shift + backspace` increases the broder width rather than changing it to default.
Now, it is fixed by changing the `static const unsigned int default_border` value to 0.